### PR TITLE
Agent Detection and Dockergento Skills Support

### DIFF
--- a/changelogs/v1.4.0.md
+++ b/changelogs/v1.4.0.md
@@ -1,0 +1,140 @@
+# Changelog v1.4.0 (2026-04-07)
+
+## ✨ New Features
+
+### AI Tools Management System
+
+**Agent Detection and Installation**
+- Implemented recursive agent file discovery supporting both flat and nested directory structures
+- Agents (`.md` files) are now properly detected and installed across all platforms
+- Added `find_agent_files()` function for recursive `.md` file discovery
+- Added `install_agents_from_directory()` function as dedicated agent installer
+- Agents are flattened to platform directory regardless of source structure
+- Agents are treated as cross-cutting tools and NOT filtered by skill types
+
+**Dockergento Skills Support**
+- Added `dockergento` skill type to `data/ai-skill-types.json`
+- Enables discovery and installation of 5 Dockergento CLI tools:
+  - `dockergento-database-exporter`
+  - `dockergento-mysql-controller`
+  - `dockergento-shell-executor`
+  - `dockergento-varnish-controller`
+  - `dockergento-xdebug-toggle`
+
+## 🐛 Bug Fixes
+
+### AI Tools Management System
+
+**Agent Installation**
+- Fixed agent detection logic that only processed directories, causing all `.md` agent files to be skipped
+- Agents from repositories like `hiberus-magento/ai-tools` now install correctly
+- Updated `install_from_repository()` to branch on resource type (agents vs skills)
+- Updated `install_filtered()` to handle agents separately without type filtering
+
+**Skill Discovery**
+- Fixed missing dockergento skill type causing ~31% of repository skills to be undiscoverable
+- All skills in configured repositories now properly shown in wizard
+
+## 🔧 Technical Details
+
+### Supported Agent Repository Structures
+
+**Flat structure**:
+```
+agents/
+├── agent-1.md
+└── agent-2.md
+```
+
+**Nested structure**:
+```
+agents/
+├── category-a/
+│   └── agent-1.md
+└── category-b/
+    └── agent-2.md
+```
+
+Both structures extract to:
+```
+.claude/agents/
+├── agent-1.md
+└── agent-2.md
+```
+
+### Installation Flow Changes
+
+**Before**:
+```
+install_from_repository()
+  └─→ for directories only (skips .md files)
+```
+
+**After**:
+```
+install_from_repository()
+  ├─→ [if agents] install_agents_from_directory()
+  │     └─→ find_agent_files() (recursive .md discovery)
+  └─→ [if skills] existing directory logic
+```
+
+### Registration
+
+- Agent `.md` files are individually tracked in `ai-registration.json`
+- Each agent file has SHA256 checksum and installation timestamp
+- Custom agents (not in registry) are preserved unless `--force` flag used
+
+## 📊 Verified Testing Results
+
+- ✅ 5 dockergento skills install correctly per platform (15 total)
+- ✅ 4 agents install correctly per platform (12 total)
+  - effort-estimator.md
+  - story-generator.md
+  - effort-item-extractor.md
+  - rfp-analyzer.md
+- ✅ 48 skills + 12 agents tracked in registration
+- ✅ Nested agent directories properly flattened
+- ✅ Backward compatible with existing configurations
+
+## 🔧 Modified Files
+
+### Data
+- `data/ai-skill-types.json` - Added dockergento skill type
+
+### Tasks
+- `console/tasks/ai_extract.sh` - Implemented agent detection and installation
+
+### Specification
+- `specs/005-ai-tools-dynamic-discovery/spec.md` - Feature specification
+
+## 📝 Usage Example
+
+```bash
+# Initialize AI tools
+hm ai-init
+
+# Wizard now shows:
+# Which skill types does your project need?
+#   [ ] 1) Hyvä Themes
+#   [ ] 2) Adobe Commerce Storefront
+#   [ ] 3) Magento 2
+#   [ ] 4) PHP
+#   [ ] 5) Dockergento CLI ← NEW
+
+# Select resources=agents to get agents installed
+# Select types=dockergento to get dockergento skills
+
+# Update existing configuration
+hm ai-pull
+```
+
+## 🔗 Related Issues
+
+Resolves issues identified in real-world testing:
+- Agents not being detected despite existing in repository
+- Dockergento skills missing from available options
+- Need for flexible repository structures
+
+---
+
+**Full Changelog**: https://github.com/hiberus-magento/hm/compare/v1.3.1...v1.4.0

--- a/console/tasks/ai_extract.sh
+++ b/console/tasks/ai_extract.sh
@@ -18,6 +18,22 @@ source "${SCRIPT_DIR}/../components/print_message.sh"
 source "${SCRIPT_DIR}/ai_registration.sh"
 
 #
+# Find all .md files in agents directory (recursive)
+# Args: $1 = agents directory path
+# Returns: List of .md file paths via stdout (one per line)
+#
+find_agent_files() {
+    local agents_dir="$1"
+
+    if [[ ! -d "${agents_dir}" ]]; then
+        return 0
+    fi
+
+    # Find all .md files recursively
+    find "${agents_dir}" -type f -name "*.md" 2>/dev/null
+}
+
+#
 # Validate repository structure
 # Args: $1 = repository root directory
 # Returns: 0 if valid (has skills/ or agents/), 1 otherwise
@@ -70,6 +86,113 @@ extract_tarball() {
 }
 
 #
+# Install agents from repository (handles .md files, supports nested directories)
+# Args: $1 = repository root directory,
+#       $2 = agents source directory,
+#       $3 = platform agents directory,
+#       $4 = force overwrite (true|false)
+# Returns: 0 on success, 1 on failure
+# Side effects: Updates ai-registration.json
+#
+install_agents_from_directory() {
+    local repo_dir="$1"
+    local source_dir="$2"
+    local platform_dir="$3"
+    local force_overwrite="$4"
+
+    # Create target directory
+    mkdir -p "${platform_dir}" || {
+        print_error_line "Failed to create target directory: ${platform_dir}"
+        return 1
+    }
+
+    # Find all .md files (recursive)
+    local agent_files
+    agent_files=$(find_agent_files "${source_dir}")
+
+    if [[ -z "${agent_files}" ]]; then
+        print_info_line "No agents found in repository"
+        return 0
+    fi
+
+    # Create temp directory for atomic operations
+    local temp_dir
+    temp_dir=$(mktemp -d "${platform_dir}/.tmp.XXXXXX")
+
+    local installed_count=0
+    local skipped_count=0
+
+    # Install each agent file
+    while IFS= read -r agent_path; do
+        [[ -z "${agent_path}" ]] && continue
+
+        # Extract filename without extension
+        local agent_name
+        agent_name=$(basename "${agent_path}" .md)
+
+        local target_path="${platform_dir}/${agent_name}.md"
+        local temp_path="${temp_dir}/${agent_name}.md"
+
+        # Check for conflicts
+        if [[ -f "${target_path}" ]]; then
+            if is_tracked "agents" "${target_path}"; then
+                print_info_line "Updating ${agent_name}..."
+            else
+                if [[ "${force_overwrite}" == "true" ]]; then
+                    print_warning_line "Overwriting custom agent: ${agent_name} (--force enabled)"
+                else
+                    print_warning_line "Skipping ${agent_name} (custom agent exists, use --force to overwrite)"
+                    ((skipped_count++))
+                    continue
+                fi
+            fi
+        else
+            print_info_line "Installing ${agent_name}..."
+        fi
+
+        # Copy to temp directory first
+        cp "${agent_path}" "${temp_path}" || {
+            print_error_line "Failed to copy ${agent_name}"
+            rm -rf "${temp_dir}"
+            return 1
+        }
+
+        # Atomic move from temp to target
+        if [[ -f "${target_path}" ]]; then
+            rm -f "${target_path}"
+        fi
+
+        mv "${temp_path}" "${target_path}" || {
+            print_error_line "Failed to install ${agent_name}"
+            rm -rf "${temp_dir}"
+            return 1
+        }
+
+        # Register installation
+        add_registration_entry "agents" "${target_path}" || {
+            print_warning_line "Failed to register ${agent_name} (continuing anyway)"
+        }
+
+        ((installed_count++))
+    done <<< "${agent_files}"
+
+    # Clean up temp directory
+    rm -rf "${temp_dir}"
+
+    # Report results
+    if [[ ${installed_count} -eq 0 ]] && [[ ${skipped_count} -eq 0 ]]; then
+        print_info_line "No agents to install"
+    else
+        print_info_line "Installed ${installed_count} agents"
+        if [[ ${skipped_count} -gt 0 ]]; then
+            print_info_line "Skipped ${skipped_count} custom agents"
+        fi
+    fi
+
+    return 0
+}
+
+#
 # Install skills/agents from repository with atomic operations
 # Args: $1 = source repository directory,
 #       $2 = resource type (skills|agents),
@@ -99,6 +222,12 @@ install_from_repository() {
     if [[ ! -d "${source_dir}" ]]; then
         print_info_line "No ${resource_type} found in repository"
         return 0
+    fi
+
+    # Handle agents (files) vs skills (directories) differently
+    if [[ "${resource_type}" == "agents" ]]; then
+        install_agents_from_directory "${repo_dir}" "${source_dir}" "${platform_dir}" "${force_overwrite}"
+        return $?
     fi
 
     # Create target directory
@@ -230,6 +359,12 @@ install_filtered() {
     if [[ ! -d "${source_dir}" ]]; then
         print_info_line "No ${resource_type} found in repository"
         return 0
+    fi
+
+    # Handle agents differently - no type filtering for agents
+    if [[ "${resource_type}" == "agents" ]]; then
+        install_agents_from_directory "${repo_dir}" "${source_dir}" "${platform_dir}" "${force_overwrite}"
+        return $?
     fi
 
     # Create target directory

--- a/data/ai-skill-types.json
+++ b/data/ai-skill-types.json
@@ -3,22 +3,47 @@
     "hyva": {
       "name": "Hyvä Themes",
       "description": "Hyvä Themes development",
-      "tags": ["frontend", "theme", "hyva"]
+      "tags": [
+        "frontend",
+        "theme",
+        "hyva"
+      ]
     },
     "acs": {
       "name": "Adobe Commerce Storefront",
-      "description": "Adobe Commerce Storefront (PWA)",
-      "tags": ["pwa", "frontend", "storefront"]
+      "description": "Adobe Commerce Storefront",
+      "tags": [
+        "pwa",
+        "frontend",
+        "storefront"
+      ]
     },
     "magento": {
       "name": "Magento 2",
       "description": "General Magento 2 development",
-      "tags": ["magento", "ecommerce", "backend"]
+      "tags": [
+        "magento",
+        "ecommerce",
+        "backend"
+      ]
     },
     "php": {
       "name": "PHP",
       "description": "PHP general development",
-      "tags": ["php", "backend"]
+      "tags": [
+        "php",
+        "backend"
+      ]
+    },
+    "dockergento": {
+      "name": "Dockergento CLI",
+      "description": "Dockergento development environment tools",
+      "tags": [
+        "cli",
+        "docker",
+        "devops",
+        "magento"
+      ]
     }
   }
 }

--- a/specs/005-ai-tools-dynamic-discovery/spec.md
+++ b/specs/005-ai-tools-dynamic-discovery/spec.md
@@ -1,0 +1,157 @@
+# AI Tools Agent Detection and Dockergento Skills Support
+
+**Branch**: `005-ai-tools-dynamic-discovery`  
+**Status**: Draft  
+**Created**: 2026-04-07
+
+## Problem Statement
+
+After real-world testing of the AI Tools Management System, two critical bugs were identified:
+
+### 1. Agents Not Being Detected
+
+The installation process reports "No matching agents found" despite agents existing in the repository.
+
+**Current behavior:**
+```
+Installing agents for claude...
+No matching agents found for types: magento,php
+```
+
+**Actual repository structure:**
+```
+agents/
+├── effort-estimator.md
+├── story-generator.md
+├── effort-item-extractor.md
+└── rfp-analyzer.md
+```
+
+**Root cause**: The agent detection logic in `ai_extract.sh` only processes **directories**, but agents are **individual `.md` files**.
+
+**Lines 119-122 in `console/tasks/ai_extract.sh`:**
+```bash
+for item_path in "${source_dir}"/*; do
+    if [[ ! -d "${item_path}" ]]; then
+        continue  # Skips files
+    fi
+```
+
+### 2. Dockergento Skills Not Available
+
+Skills with `dockergento-*` prefix exist in `hiberus-magento/ai-tools` repository but are never shown in the wizard.
+
+**Missing skills** (~31% of repository):
+- `dockergento-database-exporter`
+- `dockergento-shell-executor`
+- `dockergento-xdebug-toggle`
+- `dockergento-mysql-controller`
+- `dockergento-varnish-controller`
+
+**Root cause**: The skill type `dockergento` doesn't exist in `data/ai-skill-types.json`.
+
+## Proposed Solution
+
+### Part 1: Fix Agent Detection with Directory Support
+
+**Approach**: Support both flat `.md` files AND directory-organized agents.
+
+**Rationale**: Provides flexibility for repositories to organize agents in subdirectories while extracting all `.md` files to platform's flat agent directory.
+
+**Supported structures:**
+
+**Flat** (current `hiberus-magento/ai-tools`):
+```
+agents/
+├── effort-estimator.md
+└── story-generator.md
+```
+
+**Organized** (future repositories):
+```
+agents/
+├── project/
+│   └── effort-estimator.md
+└── code/
+    └── analyzer.md
+```
+
+Both extract to:
+```
+.claude/agents/
+├── effort-estimator.md
+└── analyzer.md
+```
+
+**Implementation overview:**
+
+1. Create `find_agent_files()` - recursive `.md` file discovery
+2. Create `install_agents_from_directory()` - agent-specific installer
+3. Update `install_from_repository()` - branch on resource type
+4. Update `install_filtered()` - branch on resource type
+5. Note: Agents are NOT filtered by skill types (they're cross-cutting tools)
+
+### Part 2: Add Dockergento Skill Type
+
+**Implementation:**
+
+Update `data/ai-skill-types.json`:
+```json
+{
+  "skill_types": {
+    "dockergento": {
+      "name": "Dockergento CLI",
+      "description": "Dockergento development environment tools",
+      "tags": ["cli", "docker", "devops", "magento"]
+    }
+  }
+}
+```
+
+## Success Criteria
+
+1. ✅ `dockergento` appears in skill types wizard
+2. ✅ All 5 `dockergento-*` skills install when type selected
+3. ✅ Agents from flat structure install correctly
+4. ✅ Agents from nested directories install correctly (flattened)
+5. ✅ Registration tracks installed agents (`.md` files)
+6. ✅ Backward compatible with existing configurations
+
+## Testing Strategy
+
+**Test 1: Dockergento Skills**
+```bash
+hm ai-reset
+hm ai-init  # Select: skills, claude, dockergento
+ls -la .claude/skills/ | grep dockergento  # Expected: 5 directories
+```
+
+**Test 2: Flat Agents**
+```bash
+hm ai-init  # Select: agents, claude
+ls -la .claude/agents/*.md  # Expected: 4 files from hiberus-magento/ai-tools
+```
+
+**Test 3: Nested Agents**
+```bash
+# Create test repo with nested structure
+mkdir -p /tmp/test-repo/agents/cat-a
+echo "---\nname: a1\n---" > /tmp/test-repo/agents/cat-a/agent-1.md
+# Modify config to use test repo
+hm ai-pull
+test -f .claude/agents/agent-1.md && echo "✓ Extracted from nested"
+```
+
+## Implementation Priority
+
+1. **Phase 1** (TRIVIAL): Add dockergento to `ai-skill-types.json`
+2. **Phase 2** (CRITICAL): Fix agent detection in `ai_extract.sh`
+
+**Files modified**:
+- `data/ai-skill-types.json`
+- `console/tasks/ai_extract.sh`
+
+## Related Documentation
+
+- Parent Spec: `specs/001-ai-tools-management/spec.md`
+- Previous Release: `changelogs/v1.3.1.md`


### PR DESCRIPTION
## Summary

      Fixes critical bugs in AI Tools Management System discovered during real-world testing:

      - **Agent detection**: Agents (`.md` files) were being skipped because installation logic only processed directories
      - **Dockergento skills**: 5 dockergento CLI tools were undiscoverable due to missing skill type

      ## Changes

      ### 1. Agent Detection and Installation
      - ✅ Implemented recursive `.md` file discovery with `find_agent_files()`
      - ✅ Created dedicated `install_agents_from_directory()` installer
      - ✅ Supports both flat and nested agent repository structures
      - ✅ Flattens all agents to platform directory (e.g., `.claude/agents/`)
      - ✅ Agents treated as cross-cutting tools (no skill type filtering)

      ### 2. Dockergento Skills Support
      - ✅ Added `dockergento` skill type to `data/ai-skill-types.json`
      - ✅ Enables installation of 5 dockergento CLI tools:
        - `dockergento-database-exporter`
        - `dockergento-mysql-controller`
        - `dockergento-shell-executor`
        - `dockergento-varnish-controller`
        - `dockergento-xdebug-toggle`

      ### 3. Installation Logic Updates
      - ✅ `install_from_repository()` branches on resource type
      - ✅ `install_filtered()` handles agents separately
      - ✅ Proper registration tracking for individual `.md` files

      ## Testing

      **Verified Results**:
      - ✅ 5 dockergento skills install per platform (15 total across claude/copilot/opencode)
      - ✅ 4 agents install per platform (12 total)
        - effort-estimator, story-generator, effort-item-extractor, rfp-analyzer
      - ✅ 48 skills + 12 agents tracked in `ai-registration.json`
      - ✅ Nested agent directories properly flattened
      - ✅ Backward compatible with existing configurations

      **Test Commands**:
      ```bash
      hm ai-reset --confirm
      hm ai-init  # Select: resources=skills+agents, platforms=claude+copilot+opencode, types=magento+php+dockergento
      ls -la .claude/skills/ | grep dockergento  # Verify 5 dockergento skills
      ls -la .claude/agents/*.md                  # Verify 4 agents
      jq '.skills | keys | length' config/docker/ai-registration.json  # 48
      jq '.agents | keys | length' config/docker/ai-registration.json  # 12
      ```

      ## Supported Agent Structures

      **Flat** (current `hiberus-magento/ai-tools`):
      ```
      agents/
      ├── agent-1.md
      └── agent-2.md
      ```

      **Nested** (future repositories):
      ```
      agents/
      ├── category-a/
      │   └── agent-1.md
      └── category-b/
          └── agent-2.md
      ```

      Both extract to: `.claude/agents/agent-1.md`, `.claude/agents/agent-2.md`

      ## Impact

      - **Users can now install agents** from repositories like `hiberus-magento/ai-tools`
      - **All skills discoverable** - no more missing 31% of repository content
      - **Flexible repository organization** - maintainers can organize agents in subdirectories
      - **Zero breaking changes** - existing configurations continue working

      ## Files Modified

      - `data/ai-skill-types.json` - Added dockergento type
      - `console/tasks/ai_extract.sh` - Agent detection and installation
      - `specs/005-ai-tools-dynamic-discovery/spec.md` - Feature specification
      - `changelogs/v1.4.0.md` - Release notes

      ## Specification

      Full specification: `specs/005-ai-tools-dynamic-discovery/spec.md`

      Closes issues identified in real-world testing feedback.