### PR TITLE
[UPD] Update docker-entrypoint.sh Composer version update command for PHP 8.x images

### DIFF
--- a/Dockerfiles/php/8.1-buster/docker-entrypoint.sh
+++ b/Dockerfiles/php/8.1-buster/docker-entrypoint.sh
@@ -4,7 +4,8 @@ sudo chown -R app:app /var/www
 if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
-if [ "$COMPOSER_VERSION" ]; then
-  sudo composer self-update --$COMPOSER_VERSION &> /dev/null
+if [ -n "$COMPOSER_VERSION" ]; then
+  echo "Updating Composer to $COMPOSER_VERSION"
+  sudo composer self-update "$COMPOSER_VERSION" || true
 fi
 exec "$@"

--- a/Dockerfiles/php/8.1/docker-entrypoint.sh
+++ b/Dockerfiles/php/8.1/docker-entrypoint.sh
@@ -4,7 +4,8 @@ sudo chown -R app:app /var/www
 if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
-if [ "$COMPOSER_VERSION" ]; then
-  sudo composer self-update --$COMPOSER_VERSION &> /dev/null
+if [ -n "$COMPOSER_VERSION" ]; then
+  echo "Updating Composer to $COMPOSER_VERSION"
+  sudo composer self-update "$COMPOSER_VERSION" || true
 fi
 exec "$@"

--- a/Dockerfiles/php/8.2-buster/docker-entrypoint.sh
+++ b/Dockerfiles/php/8.2-buster/docker-entrypoint.sh
@@ -4,7 +4,8 @@ sudo chown -R app:app /var/www
 if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
-if [ "$COMPOSER_VERSION" ]; then
-  sudo composer self-update --$COMPOSER_VERSION &> /dev/null
+if [ -n "$COMPOSER_VERSION" ]; then
+  echo "Updating Composer to $COMPOSER_VERSION"
+  sudo composer self-update "$COMPOSER_VERSION" || true
 fi
 exec "$@"

--- a/Dockerfiles/php/8.3-bookworm/docker-entrypoint.sh
+++ b/Dockerfiles/php/8.3-bookworm/docker-entrypoint.sh
@@ -4,7 +4,8 @@ sudo chown -R app:app /var/www
 if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
-if [ "$COMPOSER_VERSION" ]; then
-  sudo composer self-update --$COMPOSER_VERSION &> /dev/null
+if [ -n "$COMPOSER_VERSION" ]; then
+  echo "Updating Composer to $COMPOSER_VERSION"
+  sudo composer self-update "$COMPOSER_VERSION" || true
 fi
 exec "$@"

--- a/Dockerfiles/php/8.4-bookworm/docker-entrypoint.sh
+++ b/Dockerfiles/php/8.4-bookworm/docker-entrypoint.sh
@@ -4,7 +4,8 @@ sudo chown -R app:app /var/www
 if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
-if [ "$COMPOSER_VERSION" ]; then
-  sudo composer self-update --$COMPOSER_VERSION &> /dev/null
+if [ -n "$COMPOSER_VERSION" ]; then
+  echo "Updating Composer to $COMPOSER_VERSION"
+  sudo composer self-update "$COMPOSER_VERSION" || true
 fi
 exec "$@"


### PR DESCRIPTION
---

## Changes

* Replaced `if [ "$COMPOSER_VERSION" ]` with `if [ -n "$COMPOSER_VERSION" ]` for a more explicit check
* Replaced `sudo composer self-update --$COMPOSER_VERSION` with `sudo composer self-update "$COMPOSER_VERSION"` to pass the version as a positional argument
* Added an echo message to log the Composer version being applied
* Added `|| true` to prevent container startup failure if the self-update command fails
* Applied to all PHP 8.x image variants: `8.1`, `8.1-buster`, `8.2-buster`, `8.3-bookworm`, `8.4-bookworm`

---

## Benefits

* Fixes compatibility issue with newer versions of Composer that no longer accept `--<version>` as a flag
* Improves robustness by preventing container crashes on Composer update failure
* More explicit and readable environment variable check

---

## Notes

* Changes are limited to PHP 8.x images
