### PR TITLE
Release 1.4.5

### DIFF
--- a/Dockerfiles/search/3-opensearch/Dockerfile
+++ b/Dockerfiles/search/3-opensearch/Dockerfile
@@ -7,7 +7,10 @@ FROM opensearchproject/opensearch:3.1.0
 # JDK reciente). Reemplazarlo provoca al arrancar:
 #   NoClassDefFoundError: org.opensearch.javaagent.bootstrap.AgentPolicy$AnyCanExit
 # -XX:UseSVE=0 silencia el warning de SVE en arm64 (Apple Silicon), es inofensivo.
-ENV OPENSEARCH_JAVA_OPTS="-Xms512m -Xmx512m -XX:UseSVE=0"
+# -XX:+IgnoreUnrecognizedVMOptions evita el fallo fatal "Unrecognized VM option
+# 'UseSVE=0'" en JDKs que no soportan ese flag (p.ej. x86_64 o versiones antiguas):
+# el flag se aplica donde existe y se ignora silenciosamente donde no.
+ENV OPENSEARCH_JAVA_OPTS="-Xms512m -Xmx512m -XX:+IgnoreUnrecognizedVMOptions -XX:UseSVE=0"
 ENV DISABLE_INSTALL_DEMO_CONFIG="true"
 ENV DISABLE_SECURITY_PLUGIN="true"
 

--- a/changelogs/README.md
+++ b/changelogs/README.md
@@ -16,6 +16,7 @@ Changelogs include:
 
 ## Versions
 
+- [v1.4.5](v1.4.5.md) - 2026-08-19 - Non-interactive `hm mysql`, OpenSearch 3 JVM flag and project-scoped container lookups
 - [v1.4.4](v1.4.4.md) - 2026-07-29 - Deployer PHP 8.3, MariaDB 12.3, RabbitMQ 4.3 and Nginx 1.30 images
 - [v1.3.0](v1.3.0.md) - 2026-04-02 - Magento 2.4.8 support, security patch backfill, data-driven image config
 - [v1.2.0](v1.2.0.md) - 2026-04-01 - AI Tools Management System

--- a/changelogs/v1.4.5.md
+++ b/changelogs/v1.4.5.md
@@ -1,0 +1,67 @@
+# Changelog v1.4.5 (2026-08-19)
+
+## 🐛 Bug Fixes
+
+### `hm mysql` unusable from non-interactive callers (CI, AI agents)
+- `console/commands/mysql.sh`: stdin was treated as a dump to import whenever there was
+  no tty (`[ ! -t 0 ]`), so any non-interactive caller running `hm mysql -q "..."` or
+  `hm mysql -i dump.sql` never reached the option parser.
+- Now the stdin-import path only triggers when **no options were passed**
+  (`hm mysql < dump.sql`), leaving `-q`, `-i`, `-d` and `-a` available everywhere.
+
+### OpenSearch 3 failed to boot on JDKs without `UseSVE`
+- `Dockerfiles/search/3-opensearch/Dockerfile`: `-XX:UseSVE=0` is an arm64-only flag,
+  and JVMs that do not recognise it abort at startup with
+  `Unrecognized VM option 'UseSVE=0'`.
+- Added `-XX:+IgnoreUnrecognizedVMOptions` before it, so the flag applies where it
+  exists (silencing the SVE warning on Apple Silicon) and is ignored elsewhere.
+
+### Container lookups leaked across compose projects
+- `docker ps -f name=<service>` matches by substring across **every** project on the
+  host: with more than one environment running it could return several container ids
+  (breaking `docker exec`) or operate on another project's containers.
+- Replaced with project-scoped `$DOCKER_COMPOSE ps -q <service>` in:
+  - `console/commands/mysql.sh` (`db`) — could have imported a dump into the wrong database
+  - `console/tasks/set_etc_hosts.sh` (`hitch`, `phpfpm`)
+- `console/commands/ssl.sh`: removed the redundant host-wide `docker ps | grep hitch`
+  check, which reported success when *any* project's hitch container was up.
+  `is_run_service "hitch"` already validates it within the current project.
+
+## 🔧 Improvements
+
+### Cache/session host detection for Valkey
+- `console/commands/install.sh`: `setup:install` hardcoded `redis` as the host for
+  session, cache and page-cache backends. Environments that name the compose service
+  `valkey` instead of `redis` got an unreachable backend.
+- The service is now detected from the compose configuration, defaulting to `redis`.
+  Standard Hiberus Dockergento projects are unaffected: `data/requirements.json` wires
+  Valkey through the existing `redis` service slot.
+
+## 🔄 Backward Compatibility
+
+- No configuration or interface changes. `hm mysql` keeps the same options and the
+  `hm mysql < dump.sql` shorthand.
+- `hiberusmagento/search:3-opensearch` is already published on Docker Hub with this
+  fix; the Dockerfile change here keeps the repository in sync with the released image.
+
+## 🔧 Modified Files
+
+### Dockerfiles
+- `Dockerfiles/search/3-opensearch/Dockerfile`
+
+### Commands
+- `console/commands/install.sh`
+- `console/commands/mysql.sh`
+- `console/commands/ssl.sh`
+
+### Tasks
+- `console/tasks/set_etc_hosts.sh`
+
+## 🙏 Contributors
+
+- [@rgarciar-hiberuscom](https://github.com/rgarciar-hiberuscom)
+- [@ddelgado-hiberuscom](https://github.com/ddelgado-hiberuscom)
+
+---
+
+**Full Changelog**: https://github.com/hiberus-magento/hiberus-dockergento/compare/1.4.4...1.4.5

--- a/console/commands/install.sh
+++ b/console/commands/install.sh
@@ -7,6 +7,14 @@ source "$COMPONENTS_DIR"/print_message.sh
 source "$HELPERS_DIR"/docker.sh
 source "$HELPERS_DIR"/version.sh
 
+# Cache/session backend service name. Magento 2.4.9+ ships Valkey (a drop-in Redis
+# replacement) and some environments name the compose service "valkey" instead of
+# "redis". Detect the real service so setup:install connects to the right host.
+cache_host="redis"
+if [ -n "${DOCKER_COMPOSE:-}" ] && $DOCKER_COMPOSE config --services 2>/dev/null | grep -qx "valkey"; then
+    cache_host="valkey"
+fi
+
 command_arguments="--db-host=db \
     --backend-frontname=admin \
     --use-rewrites=1 \
@@ -14,14 +22,14 @@ command_arguments="--db-host=db \
     --db-user=magento \
     --db-password=magento \
     --session-save=redis \
-    --session-save-redis-host=redis \
+    --session-save-redis-host=$cache_host \
     --session-save-redis-db=0 \
     --session-save-redis-disable-locking=1 \
     --cache-backend=redis \
-    --cache-backend-redis-server=redis \
+    --cache-backend-redis-server=$cache_host \
     --cache-backend-redis-db=1 \
     --page-cache=redis \
-    --page-cache-redis-server=redis \
+    --page-cache-redis-server=$cache_host \
     --page-cache-redis-db=2 \
     --amqp-host=rabbitmq \
     --amqp-port=5672 \

--- a/console/commands/mysql.sh
+++ b/console/commands/mysql.sh
@@ -4,7 +4,11 @@ set -euo pipefail
 source "$COMPONENTS_DIR"/print_message.sh
 source "$TASKS_DIR"/set_magento_configs.sh
 source "$HELPERS_DIR"/docker.sh
-mysql_container=$(docker ps -qf "name=db")
+# Resolve the db container within the current compose project. `docker ps -f name=db`
+# matches by substring across ALL projects on the host, so with more than one
+# environment up it could return several ids (breaking `docker exec`) or target
+# another project's database.
+mysql_container=$($DOCKER_COMPOSE ps -q db)
 
 # Check if db service is running
 is_run_service "db"
@@ -59,8 +63,11 @@ mysql_execute() {
     $DOCKER_COMPOSE exec db bash -c "$db_client"
 }
 
-# If stdin has content
-if [ ! -t 0 ]; then
+# Only treat a non-tty stdin as a dump to import when no options were given
+# (e.g. `hm mysql < dump.sql`). Non-interactive callers (CI, agents) invoking
+# `hm mysql -q ...` never have a tty either, so gating solely on `[ ! -t 0 ]`
+# made -q/-i unreachable for them.
+if [[ $# -eq 0 ]] && [ ! -t 0 ]; then
     print_info "Importing database from stdin ...\n"
     docker exec -i $mysql_container bash -c "$db_client"
 else

--- a/console/commands/ssl.sh
+++ b/console/commands/ssl.sh
@@ -11,11 +11,6 @@ else
     DOMAIN=$1
 fi
 
-if [ -z "$(docker ps | grep hitch)" ]; then
-    print_error "Error: Hitch is not running!\n"
-    exit
-fi
-
 print_info "Generating SSL certificates for domain "
 print_default "$DOMAIN"
 print_info "...\n"

--- a/console/tasks/set_etc_hosts.sh
+++ b/console/tasks/set_etc_hosts.sh
@@ -9,7 +9,7 @@ is_run_service "phpfpm"
 is_run_service "hitch"
 
 # Get IP Address of hitch container
-DOCKER_IP=`docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker ps -qf "name=hitch")`
+DOCKER_IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$($DOCKER_COMPOSE ps -q hitch)")
 
 # Read domains from database and include them into /etc/hosts file of php container
 for DOMAIN in `"$COMMANDS_DIR"/mysql.sh -q "SELECT DISTINCT value FROM core_config_data WHERE path like 'web/%/base_url'" 2> /dev/null`
@@ -24,6 +24,6 @@ $DOCKER_COMPOSE exec -uroot phpfpm bash -c "echo \"$DOCKER_IP localhost\" >> /et
 # Copy local certificates to php container
 if [ -d "/usr/local/share/ca-certificates" ];
 then
-  docker cp /usr/local/share/ca-certificates $(docker ps -qf "name=phpfpm"):/usr/local/share/
+  docker cp /usr/local/share/ca-certificates "$($DOCKER_COMPOSE ps -q phpfpm)":/usr/local/share/
   $DOCKER_COMPOSE exec -uroot phpfpm update-ca-certificates > /dev/null 2> /dev/null
 fi


### PR DESCRIPTION
Release **1.4.5** — see [`changelogs/v1.4.5.md`](changelogs/v1.4.5.md).

## 🐛 Bug Fixes

- **`hm mysql` unusable from non-interactive callers (CI, AI agents)** — stdin was treated as a dump to import whenever there was no tty, so `hm mysql -q "..."` / `-i` never reached the option parser. The stdin-import path now only triggers when no options are passed (`hm mysql < dump.sql`).
- **OpenSearch 3 aborted on JVMs without `UseSVE`** — `-XX:UseSVE=0` is arm64-only and unrecognised elsewhere. Added `-XX:+IgnoreUnrecognizedVMOptions` before it. The image `hiberusmagento/search:3-opensearch` is already published with this fix; this change keeps the repo in sync.
- **Container lookups leaked across compose projects** — `docker ps -f name=<service>` matches by substring across *every* project on the host, so with several environments up it could return multiple ids or hit another project's containers (`hm mysql -i dump.sql` could have imported into the wrong database). Replaced with project-scoped `$DOCKER_COMPOSE ps -q <service>` in `mysql.sh` and `set_etc_hosts.sh`, and removed the redundant host-wide hitch check in `ssl.sh`.

## 🔧 Improvements

- **Cache/session host detection for Valkey** — `setup:install` hardcoded `redis` as the session/cache/page-cache host. The service is now detected from the compose configuration, defaulting to `redis`. Standard projects are unaffected: Valkey is wired through the existing `redis` service slot in `data/requirements.json`.

## 🔄 Backward Compatibility

No configuration or interface changes. `hm mysql` keeps the same options and the `hm mysql < dump.sql` shorthand.

## Verification

- `bash -n` on every modified script.
- Live check against a running project: `hm mysql -q "SELECT 1"` now works without a tty, resolving the `db` container within its own compose project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpgnhaD9NxKvxnLNj8Lv57